### PR TITLE
Fix crash in no-unused-dependencies

### DIFF
--- a/lib/rules/no-unused-dependencies.js
+++ b/lib/rules/no-unused-dependencies.js
@@ -21,20 +21,41 @@ module.exports = {
 
 	create: function(context) {
 		// Used during parsing to keep track of state
-		let dependencies = null
-		let usedClassProps = null
+		/** @type {{}[]} */
+		const scopeStack = []
+		/** @type {WeakMap<{}, { dependencies: Set<{ value: string }>; usedClassProps: Set<string> }>} */
+		const deps = new WeakMap()
 
 		return {
 			// As we enter a class, clear out the state
-			ClassBody: () => {
-				dependencies = new Set()
-				usedClassProps = new Set()
+			ClassBody () {
+				const scope = context.getScope()
+				scopeStack.push(scope)
+				deps.set(scope, {
+					dependencies: new Set(),
+					usedClassProps: new Set(),
+				})
+			},
+
+			// As we exit the class body, compare deps to what was used
+			'ClassBody:exit' () {
+				const {dependencies, usedClassProps} = deps.get(scopeStack.pop())
+
+				dependencies.forEach(dep => {
+					if (!usedClassProps.has(dep.value)) {
+						context.report(dep, `Dependency '${dep.value}' is unused`)
+					}
+				})
 			},
 
 			// Find the dependencies prop if it exists
-			ClassProperty: node => {
+			ClassProperty (node) {
 				// Only care about static dependencies
 				if (!node.static || node.key.name !== 'dependencies') { return }
+
+				// we should only reach this actually inside a ClassBody so should have at least one scope there
+				const scope = scopeStack[scopeStack.length - 1]
+				const {dependencies} = deps.get(scope)
 
 				// Value is an ArrayExpression, grab all the Literal elements from it
 				node.value.elements.forEach(elem => {
@@ -44,20 +65,14 @@ module.exports = {
 			},
 
 			// Deps are exposed as `this.<handle>`, track all member access on `this`
-			MemberExpression: node => {
-				if (node.object.type !== 'ThisExpression') {
+			MemberExpression (node) {
+				// if not inside a class just return
+				if (scopeStack.length < 1 || node.object.type !== 'ThisExpression') {
 					return
 				}
+				const scope = scopeStack[scopeStack.length - 1]
+				const {usedClassProps} = deps.get(scope)
 				usedClassProps.add(node.property.name)
-			},
-
-			// As we exit the class body, compare deps to what was used
-			'ClassBody:exit': () => {
-				dependencies.forEach(dep => {
-					if (!usedClassProps.has(dep.value)) {
-						context.report(dep, `Dependency '${dep.value}' is unused`)
-					}
-				})
 			},
 		}
 	},

--- a/tests/lib/rules/no-unused-dependencies.js
+++ b/tests/lib/rules/no-unused-dependencies.js
@@ -41,6 +41,30 @@ export default class Something extends Module {
 	}
 }
 		`,
+		`
+const notAClass = {
+	dependencies: [],
+	method () { this.notADep }
+}
+		`,
+		`
+import Module from 'parser/core/module'
+// silly example of nested classes but verifies that the scoping system works
+class A extends Module {
+	static dependencies = ['foo']
+	static B = class B extends Module {
+		static dependencies = ['bar']
+
+		method () {
+			this.bar
+		}
+	}
+
+	method () {
+		this.foo
+	}
+}
+		`,
 	],
 
 	invalid: [


### PR DESCRIPTION
The transform was assuming any access to `this` is inside a class, but it can also be in a regular function or object method outside of a class scope.

It's also technically possible to have nested classes :notlikeduck:
